### PR TITLE
Fiber Base Config (abolfazl.beh)

### DIFF
--- a/configs/dev/http.json
+++ b/configs/dev/http.json
@@ -1,7 +1,27 @@
 {
   "servers": [
     {
-      "addr": ":3000"
+      "addr": ":3000",
+      "conf": {
+        "server_header": "",
+        "strict_routing": false,
+        "case_sensitive": false,
+        "unescape_path": false,
+        "etag": false,
+        "body_limit": 4194304,
+        "concurrency": 262144,
+        "read_timeout": -1,
+        "write_timeout": -1,
+        "idle_timeout": -1,
+        "read_buffer_size": 4096,
+        "write_buffer_size": 4096,
+        "compressed_file_suffix": ".gz",
+        "get_only": false,
+        "disable_keepalive": false,
+        "network": "tcp",
+        "enable_print_routes": true,
+        "attach_error_handler": true
+      }
     }
   ]
 }

--- a/configs/http_sample.json
+++ b/configs/http_sample.json
@@ -1,7 +1,27 @@
 {
   "servers": [
     {
-      "addr": ":3000"
+      "addr":                   ":3000",
+      "conf": {
+        "server_header": "",
+        "strict_routing": false,
+        "case_sensitive": false,
+        "unescape_path": false,
+        "etag": false,
+        "body_limit": 4194304,
+        "concurrency": 262144,
+        "read_timeout": -1,
+        "write_timeout": -1,
+        "idle_timeout": -1,
+        "read_buffer_size": 4096,
+        "write_buffer_size": 4096,
+        "compressed_file_suffix": ".gz",
+        "get_only": false,
+        "disable_keepalive": false,
+        "network": "tcp",
+        "enable_print_routes": true,
+        "attach_error_handler": true
+      }
     }
   ]
 }

--- a/configs/test/http.json
+++ b/configs/test/http.json
@@ -1,7 +1,27 @@
 {
   "servers": [
     {
-      "addr": ":3000"
+      "addr": ":3000",
+      "conf": {
+        "server_header": "",
+        "strict_routing": false,
+        "case_sensitive": false,
+        "unescape_path": false,
+        "etag": false,
+        "body_limit": 4194304,
+        "concurrency": 262144,
+        "read_timeout": -1,
+        "write_timeout": -1,
+        "idle_timeout": -1,
+        "read_buffer_size": 4096,
+        "write_buffer_size": 4096,
+        "compressed_file_suffix": ".gz",
+        "get_only": false,
+        "disable_keepalive": false,
+        "network": "tcp",
+        "enable_print_routes": true,
+        "attach_error_handler": true
+      }
     }
   ]
 }

--- a/internal/http/manager.go
+++ b/internal/http/manager.go
@@ -44,7 +44,7 @@ func (m *manager) init() {
 			continue
 		}
 
-		obj := ServerConfig{}
+		var obj ServerConfig
 		err := json.Unmarshal(jsonBody, &obj)
 		if err == nil {
 			server, err1 := NewServer(obj)

--- a/internal/http/manager_test.go
+++ b/internal/http/manager_test.go
@@ -1,11 +1,33 @@
 package http
 
 import (
+	"reflect"
 	"testing"
 	"zhycan/internal/config"
 )
 
-func Test_StartManager(t *testing.T) {
+func TestManager_Init(t *testing.T) {
+	makeReadyConfigManager()
+
+	m := manager{}
+	m.init()
+
+	if m.name != "http" {
+		t.Errorf("Expected manager name to be 'http', got '%s'", m.name)
+	}
+	if len(m.servers) == 0 {
+		t.Errorf("Expected manager to have at least one server, got '%d'", len(m.servers))
+	}
+}
+
+func TestGetManager(t *testing.T) {
+	m := GetManager()
+	if m == nil {
+		t.Errorf("Expected manager instance to be not nil, got '%v'", m)
+	}
+}
+
+func TestManger_StartServers(t *testing.T) {
 	makeReadyConfigManager()
 
 	// Get instance of manager
@@ -13,6 +35,38 @@ func Test_StartManager(t *testing.T) {
 	if err != nil {
 		t.Errorf("Starting HTTP Manager --> Expected: %v, but got %v", nil, err)
 	}
+}
+
+func TestManager_StopServers(t *testing.T) {
+	makeReadyConfigManager()
+
+	// Get instance of manager
+	err := GetManager().StopServers()
+	if err != nil {
+		t.Errorf("Stopping HTTP Manager --> Expected: %v, but got %v", nil, err)
+	}
+}
+
+func TestManager_CheckServerConfig(t *testing.T) {
+	makeReadyConfigManager()
+
+	// Get the first server
+	m := GetManager()
+	if len(m.servers) == 0 {
+		t.Errorf("Expected manager to have at least one server, got '%d'", len(m.servers))
+	}
+
+	// check the configs
+	expectedAddress := ":3000"
+	if !reflect.DeepEqual(m.servers[0].config.ListenAddress, expectedAddress) {
+		t.Errorf("Expected the Addr of the first server to be %v, but got %v", expectedAddress, m.servers[0].config.ListenAddress)
+	}
+
+	expectedVal := ".gz"
+	if !reflect.DeepEqual(m.servers[0].config.Config.CompressedFileSuffix, expectedVal) {
+		t.Errorf("Expected the config val of the first server to be %v, but got %v", expectedVal, m.servers[0].config.Config.CompressedFileSuffix)
+	}
+
 }
 
 func makeReadyConfigManager() {

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -2,4 +2,24 @@ package http
 
 type ServerConfig struct {
 	ListenAddress string `json:"addr"`
+	Config        struct {
+		ServerHeader         string `json:"server_header"`
+		StrictRouting        bool   `json:"strict_routing"`
+		CaseSensitive        bool   `json:"case_sensitive"`
+		UnescapePath         bool   `json:"unescape_path"`
+		Etag                 bool   `json:"etag"`
+		BodyLimit            int    `json:"body_limit"`
+		Concurrency          int    `json:"concurrency"`
+		ReadTimeout          int    `json:"read_timeout"`
+		WriteTimeout         int    `json:"write_timeout"`
+		IdleTimeout          int    `json:"idle_timeout"`
+		ReadBufferSize       int    `json:"read_buffer_size"`
+		WriteBufferSize      int    `json:"write_buffer_size"`
+		CompressedFileSuffix string `json:"compressed_file_suffix"`
+		GetOnly              bool   `json:"get_only"`
+		DisableKeepalive     bool   `json:"disable_keepalive"`
+		Network              string `json:"network"`
+		EnablePrintRoutes    bool   `json:"enable_print_routes"`
+		AttachErrorHandler   bool   `json:"attach_error_handler"`
+	} `json:"conf"`
 }

--- a/internal/http/types_test.go
+++ b/internal/http/types_test.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestServerConfig_UnmarshalJson(t *testing.T) {
+	// Test input data
+	input := []byte(`{
+      "addr":                   ":3000",
+      "conf": {
+        "server_header": "",
+        "strict_routing": false,
+        "case_sensitive": false,
+        "unescape_path": false,
+        "etag": false,
+        "body_limit": 4194304,
+        "concurrency": 262144,
+        "read_timeout": -1,
+        "write_timeout": -1,
+        "idle_timeout": -1,
+        "read_buffer_size": 4096,
+        "write_buffer_size": 4096,
+        "compressed_file_suffix": ".gz",
+        "get_only": false,
+        "disable_keepalive": false,
+        "network": "tcp",
+        "enable_print_routes": true,
+        "attach_error_handler": true
+      }
+    }`)
+
+	// Test expected result
+	expected := ServerConfig{
+		ListenAddress: ":3000",
+		Config: struct {
+			ServerHeader         string `json:"server_header"`
+			StrictRouting        bool   `json:"strict_routing"`
+			CaseSensitive        bool   `json:"case_sensitive"`
+			UnescapePath         bool   `json:"unescape_path"`
+			Etag                 bool   `json:"etag"`
+			BodyLimit            int    `json:"body_limit"`
+			Concurrency          int    `json:"concurrency"`
+			ReadTimeout          int    `json:"read_timeout"`
+			WriteTimeout         int    `json:"write_timeout"`
+			IdleTimeout          int    `json:"idle_timeout"`
+			ReadBufferSize       int    `json:"read_buffer_size"`
+			WriteBufferSize      int    `json:"write_buffer_size"`
+			CompressedFileSuffix string `json:"compressed_file_suffix"`
+			GetOnly              bool   `json:"get_only"`
+			DisableKeepalive     bool   `json:"disable_keepalive"`
+			Network              string `json:"network"`
+			EnablePrintRoutes    bool   `json:"enable_print_routes"`
+			AttachErrorHandler   bool   `json:"attach_error_handler"`
+		}{
+			ServerHeader:         "",
+			StrictRouting:        false,
+			CaseSensitive:        false,
+			UnescapePath:         false,
+			Etag:                 false,
+			BodyLimit:            4194304,
+			Concurrency:          262144,
+			ReadTimeout:          -1,
+			WriteTimeout:         -1,
+			IdleTimeout:          -1,
+			ReadBufferSize:       4096,
+			WriteBufferSize:      4096,
+			CompressedFileSuffix: ".gz",
+			GetOnly:              false,
+			DisableKeepalive:     false,
+			Network:              "tcp",
+			EnablePrintRoutes:    true,
+			AttachErrorHandler:   true,
+		},
+	}
+
+	// Unmarshal the input data into a ServerConfig instance
+	var config ServerConfig
+	err := json.Unmarshal(input, &config)
+	if err != nil {
+		t.Errorf("Error unmarshaling JSON: %v", err)
+	}
+
+	// Check if the result is what we expected
+	if config != expected {
+		t.Errorf("Expected %+v, got %+v", expected, config)
+	}
+}


### PR DESCRIPTION
- Fiber basic configurations are added to the config file and, it's loaded by the manager and as an object is passed to the wrapper. 
- Some unit tests are implemented for HTTP manager and types