### PR TITLE
Enabling Middleware (abolfazl.beh)

### DIFF
--- a/configs/http_sample.json
+++ b/configs/http_sample.json
@@ -24,6 +24,9 @@
         "network": "tcp",
         "enable_print_routes": true,
         "attach_error_handler": true
+      },
+      "middlewares": {
+        "order": ["logger"]
       }
     }
   ]

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -24,4 +24,7 @@ type ServerConfig struct {
 		EnablePrintRoutes    bool   `json:"enable_print_routes"`
 		AttachErrorHandler   bool   `json:"attach_error_handler"`
 	} `json:"conf"`
+	Middlewares struct {
+		Order []string `json:"order"`
+	} `json:"middlewares"`
 }

--- a/internal/http/types_test.go
+++ b/internal/http/types_test.go
@@ -31,7 +31,10 @@ func TestServerConfig_UnmarshalJson(t *testing.T) {
         "network": "tcp",
         "enable_print_routes": true,
         "attach_error_handler": true
-      }
+      },
+      "middlewares": {
+		"order": ["logger"]
+	  }
     }`)
 
 	// Test expected result
@@ -81,6 +84,9 @@ func TestServerConfig_UnmarshalJson(t *testing.T) {
 			EnablePrintRoutes:    true,
 			AttachErrorHandler:   true,
 		},
+		Middlewares: struct {
+			Order []string `json:"order"`
+		}{Order: []string{"logger"}},
 	}
 
 	// Unmarshal the input data into a ServerConfig instance


### PR DESCRIPTION
- Middleware is read from config file and will be attached to the Fiber wrapper with default configuration
- They are just default middlewares that exist with Fiber